### PR TITLE
New Documentation Section and Design Doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Odilia Website
+
+This is the markdown and configuration files for the Odilia screen reader main site.
+
+You can serve a local version of the content using the following command:
+
+```bash
+$ hugo serve
+```
+
+Please feel free to open a pull-request or issue to suggest new content, fix spelling or grammar mistakes, etc.
+And thank you to those of you who have already done so!
+

--- a/content/_index.md
+++ b/content/_index.md
@@ -60,5 +60,6 @@ symbolism behind them.
 
 ## Under Active Development
 
-This website as well as the software itself is in its early stages and under active development, please check back at a
-later stage to see more exciting news and documentation, or [subscribe to our RSS feed](news/index.xml).
+This website as well as the software itself is in its early stages and under active development!
+We're actively looking for contributors!
+Please feel free to open an issue in Github or create a pull-request for new features.

--- a/content/_index.md
+++ b/content/_index.md
@@ -9,13 +9,8 @@ menu:
 
 # Welcome to Odilia!
 
-Accessibility on Linux has historically been under-developed, under-maintained, and therefore not up to modern standards
-for many blind people. We're here to help with that!
-
 Odilia is a new screen reader for the Linux desktop. It's written in [Rust](https://rust-lang.org), for maximum
 performance and stability.
-
-<!--more-->
 
 On top of what screen reading features we already have on Linux, we intend to add roughly the following:
 
@@ -24,7 +19,7 @@ On top of what screen reading features we already have on Linux, we intend to ad
 You're no longer limited to built-in functionality! Install addons from third-party developers to extend Odilia with
 new commands and abilities. Or, if you're a developer, write your own in one of several languages.
 
-## Object Nav
+## Object Navigation
 
 Navigate applications as a tree of accessible objects, making it easy to interact with parts of the interface that are
 partly inaccessible, don't play well with keyboard focus, or are hard to use. No mouse required!

--- a/content/authors/tait-hoyem/_index.md
+++ b/content/authors/tait-hoyem/_index.md
@@ -7,16 +7,11 @@ github: TTWNO
 website: tait.tech
 ---
 
-I went to school for software development, then quit my first full-time job within 6 months of getting it to work on open-source accessibility tools.
-
 I got involved with Odilia basically by accident.
 I didn't use a screenreader on Linux because the existing options were slow on my PinebookPro and Raspberry Pi.
-But I really did need one.
-I can tell you, the amount of times I need to squint, or get really close to the screen is uncountably infinite.
-And yet, there I sat, refusing to accept the fact that I needed a screenreader, because I didn't like the options available to me.
 
-So when I heard about a possible new screenreader for Linux, written in Rust (a language I always wanted an excuse to learn about), I joined the Discord just to *observe* and *comment*.
-Within a month I started writing code, and within two months I decided that this (and some other projects I'm working on) are more important than work and quit to pursue more important things: working for myself and working on open-source accessibility tools;
-whenever I have an opportunity to have those two overlap is extra-special!
+When I heard about a possible new screenreader for Linux, written in Rust (a language I always wanted an excuse to learn about), I joined the Discord channel just to *observe* and *comment*.
+Within a month I started contributing.
+I've learned a ton from the others involved in the project, especially [FakeVIP](/authors/thefake-vip/).
 
-Find me at my main site: [tait.tech](https://tait.tech/).
+I dedicate (almost) every Saturday to the development of Odilia.

--- a/content/community.md
+++ b/content/community.md
@@ -18,13 +18,10 @@ directly]({{< relref "authors" >}}) if you wish.
 
 ## Contributing
 
-This is a very young project, we appreciate any and all contributions! However, please be aware there is a very llarge
-learning curve to helping with this project, particularly due to the lack of documentation, or **complete**
-documentation, of many of the libraries and technologies that comprise the Linux accessibility stack. For this reason,
-we are currently focused on learning as much as we can, and writing code to take advantage of it, and we don't have lots
-of time to mentor new contributors or review pull requests.
+There are many ways you can contribute to Odilia.
 
-Once the ground-work has been layed, accepting contributions should get much easier. We are greatful for your
-cooperation in this regard!
-
+1. If you're a developer, send us a pull-request. Help us make Odilia better by fixing an [outstanding issue](https://github.com/odilia-app/odilia/issues/).
+2. If you're a user, [install Odilia](/doc/user/installation/), and *report your bugs and feature requests to us* [on Github](https://github.com/odilia-app/odilia/issues/). If you don't have a Github account, feel free to send an email to [issues@odilia.app](mailto:issues@odilia.app) and we'll add the issue on Github for you.
+3. If you believe in our cause, consider donating to one of us, as we continue to develop this project. It allows us to spend more time on Odilia, and less time at work.
+    * Tait Hoyem -- [Librapay](https://liberapay.com/tait/)
 

--- a/content/community.md
+++ b/content/community.md
@@ -21,7 +21,7 @@ directly]({{< relref "authors" >}}) if you wish.
 There are many ways you can contribute to Odilia.
 
 1. If you're a developer, send us a pull-request. Help us make Odilia better by fixing an [outstanding issue](https://github.com/odilia-app/odilia/issues/).
-2. If you're a user, [install Odilia](/doc/user/installation/), and *report your bugs and feature requests to us* [on Github](https://github.com/odilia-app/odilia/issues/). If you don't have a Github account, feel free to send an email to [issues@odilia.app](mailto:issues@odilia.app) and we'll add the issue on Github for you.
+2. If you're a user, [install Odilia](/doc/user/installation/), and *report your bugs and feature requests to us* [on Github](https://github.com/odilia-app/odilia/issues/).
 3. If you believe in our cause, consider donating to one of us, as we continue to develop this project. It allows us to spend more time on Odilia, and less time at work.
     * Tait Hoyem -- [Librapay](https://liberapay.com/tait/)
 

--- a/content/doc/_index.md
+++ b/content/doc/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Documentation
 date: 2022-07-20T13:07:34+01:00
-draft: true
+draft: false
 menu:
   main:
     weight: -110

--- a/content/doc/devel/_index.md
+++ b/content/doc/devel/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Developer Documentation"
 date: 2022-07-20T13:27:24+01:00
-draft: true
+draft: false
 ---
 
 Documentation and notes for Odilia developers and contributors.

--- a/content/doc/devel/design.md
+++ b/content/doc/devel/design.md
@@ -1,6 +1,39 @@
 ---
-title: "Design Overview"
+title: "Design"
+linkTitle: "Design Overview"
 date: 2022-07-24T13:53:51+01:00
 draft: true
+aliases:
+  - /design
 ---
 
+## Inter-Process Communication - DBus
+
+Accessibility naturally requires inter-process communication (IPC), so that
+assistive technologies like Odilia can get information from, and send events
+to, the applications they're presenting to the user. On the Linux desktop, this is handled by [DBus][dbus].
+
+[dbus]: <https://www.freedesktop.org/wiki/Software/dbus/>
+
+We use the [zbus crate][zbus] ([book][zbus-book]) to talk over DBus. It is asynchronous by default, and integrates well with the [Tokio async runtime](#asynchronous-runtime---tokio).
+
+[zbus]: <https://crates.io/crates/zbus>
+[zbus-book]: <https://dbus.pages.freedesktop.org/zbus/1.0/>
+
+## Asynchronous Runtime - Tokio
+
+On Unix-like operating systems, IPC is usually handled using [Unix
+domain][uds] [sockets][sockets] (UDS). These sockets act very similar to
+networking sockets: they're an asynchronous method of communication, where data
+could arrive at any time.
+
+[sockets]: <https://manpages.ubuntu.com/manpages/kinetic/en/man7/socket.7.html>
+[uds]: <https://manpages.ubuntu.com/manpages/kinetic/en/man7/unix.7.html>
+
+For this reason, we've chosen an asynchronous architecture, which can react to
+events as they arrive, and can parallelise the sending and receiving of data
+through cooperative multitasking.
+
+Odilia uses the [Tokio runtime](https://tokio.rs) to achieve this. A good
+knowledge of Tokio is one of the fundamental building blocks to understanding,
+and contributing to, the Odilia codebase, so go take a look at the [Tokio documentation](https://docs.rs/tokio).

--- a/content/doc/devel/design.md
+++ b/content/doc/devel/design.md
@@ -7,20 +7,54 @@ aliases:
   - /design
 ---
 
-## Inter-Process Communication - DBus
+## Components
 
-Accessibility naturally requires inter-process communication (IPC), so that
-assistive technologies like Odilia can get information from, and send events
-to, the applications they're presenting to the user. On the Linux desktop, this is handled by [DBus][dbus].
+Screen readers are complex applications that need to interact with many different systems and technologies, and Odilia
+is no different. For this reason, the project is split into several crates:
 
-[dbus]: <https://www.freedesktop.org/wiki/Software/dbus/>
+### [Odilia][repo] -- The main application
 
-We use the [zbus crate][zbus] ([book][zbus-book]) to talk over DBus. It is asynchronous by default, and integrates well with the [Tokio async runtime](#asynchronous-runtime---tokio).
+[repo]: <https://github.com/odilia-app/odilia>
 
-[zbus]: <https://crates.io/crates/zbus>
-[zbus-book]: <https://dbus.pages.freedesktop.org/zbus/1.0/>
+This is the toplevel binary crate, which glues all the smaller crates together. It also handles logging and other
+application-wide tasks.
 
-## Asynchronous Runtime - Tokio
+### [atspi][atspi-crate] -- Accessibility Interface
+
+[atspi-crate]: <https://github.com/odilia-app/odilia/tree/main/atspi>
+
+This crate communicates with the [Assistive Technology Service Provider Interface][at-spi], which allows Odilia to
+access and present the content in applications and the desktop environment.
+
+[at-spi]: <https://www.freedesktop.org/wiki/Accessibility/AT-SPI>
+
+### [odilia-common][odilia-common] -- Common Algorithms, Data Types and Structures
+
+[odilia-common]: <https://github.com/odilia-app/odilia/tree/main/common>
+
+These are miscellaneous pieces of code shared by other Odilia crates. Among them are the code necessary to parse and
+work with keybindings, types used in structural navigation, and types used to read configuration files.
+
+### [odilia-input][odilia-input] -- Input Methods and Events
+
+[odilia-input]: <https://github.com/odilia-app/odilia/tree/main/input>
+
+This crate is responsible for handling input events from devices such as keyboards, mice, and touch screens. It can
+swallow input events or pass them onto the application.
+
+### [odilia-tts][odilia-tts] -- Text to Speech
+
+[odilia-tts]: <https://github.com/odilia-app/odilia/tree/main/tts>
+
+This handles talking to [speech-dispatcher][speechd] for text to speech synthesis, as well as formatting messages to be
+spoken.
+
+[speechd]: <https://freebsoft.org/speechd>
+## Dependencies and Technologies
+
+### [Tokio][tokio] -- Asynchronous Runtime
+
+[tokio]: <https://tokio.rs>
 
 On Unix-like operating systems, IPC is usually handled using [Unix
 domain][uds] [sockets][sockets] (UDS). These sockets act very similar to
@@ -34,6 +68,34 @@ For this reason, we've chosen an asynchronous architecture, which can react to
 events as they arrive, and can parallelise the sending and receiving of data
 through cooperative multitasking.
 
-Odilia uses the [Tokio runtime](https://tokio.rs) to achieve this. A good
-knowledge of Tokio is one of the fundamental building blocks to understanding,
-and contributing to, the Odilia codebase, so go take a look at the [Tokio documentation](https://docs.rs/tokio).
+Odilia uses the [Tokio runtime][tokio] to achieve this. A good knowledge of Tokio is one of the fundamental building
+blocks to understanding, and contributing to, the Odilia codebase, so go take a look at the [Tokio
+documentation][tokio-docs].
+
+[tokio-docs]: <https://docs.rs/tokio>
+
+Tokio integrates with Rust's built-in async / await syntax and [Futures][futures], so if you're unfamiliar with them,
+the [Rust Async Book][rust-async-book] is a good place to start.
+
+[futures]: <https://doc.rust-lang.org/stable/std/future/index.html>
+[rust-async-book]: <https://rust-lang.github.io/async-book/>
+
+### [DBus][dbus] -- Inter-Process Communication
+
+[dbus]: <https://www.freedesktop.org/wiki/Software/dbus/>
+
+Accessibility naturally requires inter-process communication (IPC), so that
+assistive technologies like Odilia can get information from, and send events
+to, the applications they're presenting to the user. On the Linux desktop, this is handled by [DBus][dbus].
+
+We use the [zbus crate][zbus] ([book][zbus-book]) to talk over DBus. It is asynchronous by default, and integrates well with the [Tokio async runtime](#tokiotokio----asynchronous-runtime).
+
+[zbus]: <https://crates.io/crates/zbus>
+[zbus-book]: <https://dbus.pages.freedesktop.org/zbus/1.0/>
+
+Most of the [atspi crate](#atspiatspi-crate----accessibility-interface) was generated using [zbus_xmlgen][zbus_xmlgen]
+from the [at-spi DBus interface XML definitions][at-spi-xml]. Note, however, that zbus_xmlgen is, at present, meant to be
+run once, and the generated bindings are to be manually tweaked and kept up to date, in order to keep them idiomatic.
+
+[zbus_xmlgen]: <https://crates.io/crates/zbus_xmlgen>
+[at-spi-xml]: <https://gitlab.gnome.org/GNOME/at-spi2-core/-/tree/main/xml>

--- a/content/doc/devel/design.md
+++ b/content/doc/devel/design.md
@@ -2,6 +2,7 @@
 title: "Design"
 linkTitle: "Design Overview"
 date: 2022-07-24T13:53:51+01:00
+lastmod: 2022-08-12T15:29:37+01:00
 draft: true
 aliases:
   - /design

--- a/content/doc/devel/design.md
+++ b/content/doc/devel/design.md
@@ -30,6 +30,14 @@ access and present the content in applications and the desktop environment.
 
 [at-spi]: <https://www.freedesktop.org/wiki/Accessibility/AT-SPI>
 
+### [odilia-cache][odilia-cache] -- A Cache for Accessibile Items on the Desktop
+
+[odilia-cache]: <https://github.com/odilia-app/odilia/tree/main/cache>
+
+This subsystem handles a cache that makes Odilia very fast.
+If you want to help in the performance department of Odilia, this is what to look at.
+Help us make the hashmap easier to index, the references faster to dereference, and the cache items easier to copy.
+
 ### [odilia-common][odilia-common] -- Common Algorithms, Data Types and Structures
 
 [odilia-common]: <https://github.com/odilia-app/odilia/tree/main/common>
@@ -41,8 +49,8 @@ work with keybindings, types used in structural navigation, and types used to re
 
 [odilia-input]: <https://github.com/odilia-app/odilia/tree/main/input>
 
-This crate is responsible for handling input events from devices such as keyboards, mice, and touch screens. It can
-swallow input events or pass them onto the application.
+This crate is responsible for handling input events from devices such as keyboards, mice, and touch screens.
+It doesn't implement any input methods, it only allows input methods to be configured.
 
 ### [odilia-tts][odilia-tts] -- Text to Speech
 
@@ -52,6 +60,7 @@ This handles talking to [speech-dispatcher][speechd] for text to speech synthesi
 spoken.
 
 [speechd]: <https://freebsoft.org/speechd>
+
 ## Dependencies and Technologies
 
 ### [Tokio][tokio] -- Asynchronous Runtime

--- a/content/doc/devel/design.md
+++ b/content/doc/devel/design.md
@@ -3,7 +3,7 @@ title: "Design"
 linkTitle: "Design Overview"
 date: 2022-07-24T13:53:51+01:00
 lastmod: 2022-08-12T15:29:37+01:00
-draft: true
+draft: false
 aliases:
   - /design
 weight: -110

--- a/content/doc/devel/design.md
+++ b/content/doc/devel/design.md
@@ -5,6 +5,7 @@ date: 2022-07-24T13:53:51+01:00
 draft: true
 aliases:
   - /design
+weight: -110
 ---
 
 ## Components

--- a/content/doc/devel/useful-links.md
+++ b/content/doc/devel/useful-links.md
@@ -1,7 +1,7 @@
 ---
 title: "Useful Links"
 date: 2022-08-12T15:07:41+01:00
-draft: true
+draft: false
 weight: -100
 ---
 

--- a/content/doc/devel/useful-links.md
+++ b/content/doc/devel/useful-links.md
@@ -5,7 +5,7 @@ draft: false
 weight: -100
 ---
 
-## At-spi
+## AT-SPI
 
 * [General overview](https://www.freedesktop.org/wiki/Accessibility/AT-SPI2/), with several links
 * [Accessible Document Navigation Using AT-SPI](https://accessibility.linuxfoundation.org/a11yspecs/atspi/adoc/ADOC_ATSPI.html#rendering)

--- a/content/doc/devel/useful-links.md
+++ b/content/doc/devel/useful-links.md
@@ -1,0 +1,31 @@
+---
+title: "Useful Links"
+date: 2022-08-12T15:07:41+01:00
+draft: true
+weight: -100
+---
+
+## At-spi
+
+* [General overview](https://www.freedesktop.org/wiki/Accessibility/AT-SPI2/), with several links
+* [Accessible Document Navigation Using AT-SPI](https://accessibility.linuxfoundation.org/a11yspecs/atspi/adoc/ADOC_ATSPI.html#rendering)
+* [API documentation](https://www.manpagez.com/html/libatspi/libatspi-2.10.1/ch01.php)
+* [Examples](https://github.com/infapi00/at-spi2-examples), including Javascript, C and Python
+* [Examples exclusively using py-atspi2](https://www.freedesktop.org/wiki/Accessibility/PyAtSpi2Example/), the human-generated bindings, not the ones generated via GObject Introspection
+* [Odilia's atspi crate](https://github.com/odilia-app/odilia/tree/main/atspi)
+
+## Speech
+
+* [libspeech library documentation](http://htmlpreview.github.io/?https://github.com/brailcom/speechd/blob/master/doc/speech-dispatcher.html)
+* [Speech Synthesis Interface Protocol (SSIP) API documentation](http://htmlpreview.github.io/?https://github.com/brailcom/speechd/blob/master/doc/ssip.html)
+* [Speech Synthesis Markup Language (SSML) Version 1.1](https://www.w3.org/TR/speech-synthesis/)
+* [Raw FFI Rust bindings to libspeech](https://crates.io/crates/speech-dispatcher-sys)
+* [Idiomatic Rust bindings to libspeech](https://crates.io/crates/speech-dispatcher), what we're currently using
+* [Pure Rust interface to speech-dispatcher](https://crates.io/crates/ssip-client), what we'd like to use
+* [Odilia's tts crate](https://github.com/odilia-app/odilia/tree/main/tts)
+
+## Braille
+
+* [Liblouis users and programmers manual](http://liblouis.org/documentation/liblouis.html)
+* [Liblouis bindings for rust](https://github.com/whentze/liblouis-rust), for braille tables and multiple braille codes, including those for the majority of languages
+* [Libbrlapi reference manual](https://brltty.app/doc/Manual-BrlAPI/English/BrlAPI.html)

--- a/content/doc/user/_index.md
+++ b/content/doc/user/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "User Documentation"
 date: 2022-07-20T13:27:12+01:00
-draft: true
+draft: false
 weight: -10
 ---
 

--- a/content/doc/user/faq.md
+++ b/content/doc/user/faq.md
@@ -4,14 +4,10 @@ date: 2022-07-20T13:31:00+01:00
 draft: false
 ---
 
-## Why doesn't my favourite keybinding work?
+## Why don't you support keybindings?
 
-Either one of the following two things have happened:
-
-1. We haven't implemented functionality for this keybinding as of yet. (Just ask nicely, and we should be able to)
-2. The keybinding is different than what you're used to. This can be tweaked by changing the contents of your `sohkdrc` file.
-
-Please feel free to reach out via [Github issues](https://github.com/odilia-app/odilia/issues/), if you think there is something missing.
+Currently, key bindings are very hard to register across arbitrary desktop environments.
+We will be working on this for the next release.
 
 ## How do I change my speech rate?
 
@@ -25,6 +21,6 @@ It accepts a value between 0 and 100.
 As a user, there are two best things you can do:
 
 1. Open new issues when there are features missing or broken [on our Github page](https://github.com/odilia-app/odilia/issues).
-2. Donate a small fraction of your monthly budget to helping us move away from our current jobs, to write software for you. We do this because we love accessibility, and we love free software; but, without external support we can only work on this in our free time.
+2. Donate a small fraction of your monthly budget to help us move away from our current jobs, to write software for you. We do this because we love accessibility, and we love free software; but, without external support we can only work on this in our free time.
     * Tait Hoyem -- [Librapay](https://liberapay.com/tait/)
 

--- a/content/doc/user/faq.md
+++ b/content/doc/user/faq.md
@@ -1,6 +1,30 @@
 ---
 title: "FAQ"
 date: 2022-07-20T13:31:00+01:00
-draft: true
+draft: false
 ---
+
+## Why doesn't my favourite keybinding work?
+
+Either one of the following two things have happened:
+
+1. We haven't implemented functionality for this keybinding as of yet. (Just ask nicely, and we should be able to)
+2. The keybinding is different than what you're used to. This can be tweaked by changing the contents of your `sohkdrc` file.
+
+Please feel free to reach out via [Github issues](https://github.com/odilia-app/odilia/issues/), if you think there is something missing.
+
+## How do I change my speech rate?
+
+Your speech rate must be changed in your speech dispatcher settings.
+This is often in a file called `speechd.conf` either in your `$XDG_HOME` directory, or in `/etc/speech-dispatcher/`.
+The value you want to change is `DefaultRate`.
+It accepts a value between 0 and 100.
+
+## How Can I Help?
+
+As a user, there are two best things you can do:
+
+1. Open new issues when there are features missing or broken [on our Github page](https://github.com/odilia-app/odilia/issues).
+2. Donate a small fraction of your monthly budget to helping us move away from our current jobs, to write software for you. We do this because we love accessibility, and we love free software; but, without external support we can only work on this in our free time.
+    * Tait Hoyem -- [Librapay](https://liberapay.com/tait/)
 

--- a/content/doc/user/guide.md
+++ b/content/doc/user/guide.md
@@ -1,7 +1,7 @@
 ---
 title: "Odilia Users Guide"
 date: 2022-07-20T13:27:16+01:00
-draft: true
+draft: false
 weight: -10
 ---
 

--- a/content/doc/user/guide.md
+++ b/content/doc/user/guide.md
@@ -15,6 +15,9 @@ we are happy to expand as feature requests arise.
 
 Here is a list of keybindings as of the latest release:
 
+* `left` and `right` -- change text granularity to a single character
+* `control + left` and `control + right` -- change text granularity to a single word
+* `up` and `down` -- change text granularity to a single line
 * `capslock + b` -- enable browse mode
   * `shift + i` -- go to previous list item
   * `i` -- go to next list item

--- a/content/doc/user/guide.md
+++ b/content/doc/user/guide.md
@@ -5,3 +5,40 @@ draft: true
 weight: -10
 ---
 
+Odilia should start speaking immediately when started.
+Some key bindings may feel familiar, like `capslock+b` for browse mode and `h` to go to the next heading.
+
+Some things may feel different.
+Note that for one thing, Odilia does not change modes automatically for you.
+This could be added in the future, but we are starting with a very minimal system to begin with;
+we are happy to expand as feature requests arise.
+
+Here is a list of keybindings as of the latest release:
+
+* `capslock + b` -- enable browse mode
+  * `shift + i` -- go to previous list item
+  * `i` -- go to next list item
+  * `shift + l` -- go to previous list
+  * `l` -- go to next list
+  * `shift + k` -- go to previous link
+  * `k` -- go to next link
+  * `shift + b` -- go to previous button
+  * `b` -- go to next button
+  * `shift + h` -- go to previous heading
+  * `h` -- go to next heading
+* `capslock + f` -- enable focus mode
+
+Suggest a new key binding by opening a new issue on [Github](https://github.com/odilia-app/odilia/issues/).
+
+## What Works
+
+* Basic structural navigation.
+* Caret navigation.
+* Tab navigation.
+
+## What Doesn't Work
+
+* QT Applications (see list of [popular QT applications](https://wiki.manjaro.org/index.php?title=List_of_Qt_Applications))
+* `aria-live` regions on a web-page will not update in real time.
+* Terminals -- Odilia will read the entire buffer, not just the new lines.
+

--- a/content/doc/user/guide.md
+++ b/content/doc/user/guide.md
@@ -6,63 +6,18 @@ weight: -10
 ---
 
 Odilia should start speaking immediately when started.
-Some key bindings may feel familiar, like `capslock+b` for browse mode and `h` to go to the next heading.
 
 Some things may feel different.
-Note that for one thing, Odilia does not change modes automatically for you.
-This could be added in the future, but we are starting with a very minimal system to begin with;
-we are happy to expand as feature requests arise.
-
-Here is a list of keybindings as of the latest release:
-
-* `left` and `right` -- change text granularity to a single character
-* `control + left` and `control + right` -- change text granularity to a single word
-* `up` and `down` -- change text granularity to a single line
-* `capslock + b` -- enable browse mode
-  * `shift + i` -- go to previous list item
-  * `i` -- go to next list item
-  * `shift + l` -- go to previous list
-  * `l` -- go to next list
-  * `shift + k` -- go to previous link
-  * `k` -- go to next link
-  * `shift + b` -- go to previous button
-  * `b` -- go to next button
-  * `shift + h` -- go to previous heading
-  * `h` -- go to next heading
-  * `shift + g` -- go to previous graphic
-  * `g` -- go to next graphic
-  * `shift + f` -- go to previous form
-  * `f` -- go to next form
-  * `shift + t` -- go to previous table
-  * `t` -- go to next table
-  * `shift + r` -- go to previous radio button
-  * `r` -- go to next radio button
-  * `shift + x` -- go to previous checkbox
-  * `x` -- go to next checkbox
-  * `shift + c` -- go to previous radio button
-  * `c` -- go to next combo box
-  * `shift + s` -- go to previous section
-  * `s` -- go to next section
-  * `shift + m` -- go to previous math
-  * `m` -- go to next math
-  * `shift + a` -- go to previous frame
-  * `a` -- go to next frame
-  * `shift + minus` -- go to previous separator
-  * `minus` -- go to next separator
-  * `shift + e` -- go to previous entry
-  * `e` -- go to next entry
-* `capslock + f` -- enable focus mode
-
-Suggest a new key binding by opening a new issue on [Github](https://github.com/odilia-app/odilia/issues/).
 
 ## What Works
 
-* Basic structural navigation.
 * Caret navigation.
 * Tab navigation.
+* `aria-live` regions on a web page will speak in real time.
 
 ## What Doesn't Work
 
-* `aria-live` regions on a web-page will not update in real time.
 * Terminals -- Odilia will read the entire buffer, not just the new lines.
+* Key bindings
+* Structural navigation
 

--- a/content/doc/user/guide.md
+++ b/content/doc/user/guide.md
@@ -26,6 +26,28 @@ Here is a list of keybindings as of the latest release:
   * `b` -- go to next button
   * `shift + h` -- go to previous heading
   * `h` -- go to next heading
+  * `shift + g` -- go to previous graphic
+  * `g` -- go to next graphic
+  * `shift + f` -- go to previous form
+  * `f` -- go to next form
+  * `shift + t` -- go to previous table
+  * `t` -- go to next table
+  * `shift + r` -- go to previous radio button
+  * `r` -- go to next radio button
+  * `shift + x` -- go to previous checkbox
+  * `x` -- go to next checkbox
+  * `shift + c` -- go to previous radio button
+  * `c` -- go to next combo box
+  * `shift + s` -- go to previous section
+  * `s` -- go to next section
+  * `shift + m` -- go to previous math
+  * `m` -- go to next math
+  * `shift + a` -- go to previous frame
+  * `a` -- go to next frame
+  * `shift + minus` -- go to previous separator
+  * `minus` -- go to next separator
+  * `shift + e` -- go to previous entry
+  * `e` -- go to next entry
 * `capslock + f` -- enable focus mode
 
 Suggest a new key binding by opening a new issue on [Github](https://github.com/odilia-app/odilia/issues/).
@@ -38,7 +60,6 @@ Suggest a new key binding by opening a new issue on [Github](https://github.com/
 
 ## What Doesn't Work
 
-* QT Applications (see list of [popular QT applications](https://wiki.manjaro.org/index.php?title=List_of_Qt_Applications))
 * `aria-live` regions on a web-page will not update in real time.
 * Terminals -- Odilia will read the entire buffer, not just the new lines.
 

--- a/content/doc/user/installation.md
+++ b/content/doc/user/installation.md
@@ -18,19 +18,14 @@ The following dependencies are required to build and run Odilia:
 
 ### Build Dependencies
 
-* [Rust](https://rust-lang.org) <!-- Todo: determine MSRV -->
-* Libclang >= 5.0, required by [Rust Bindgen](https://github.com/rust-lang/rust-bindgen)see [this
-  page](https://rust-lang.github.io/rust-bindgen/requirements.html)
-    * This is required for generating the Rust bindings to libspeech
+* [Rust](https://rust-lang.org)
 
 ### Runtime Dependenceis
 
-* [speech-dispatcher](https://freebsoft.org/speechd) >= 0.9 (>= 0.10 recommended) - text to speech daemon
-    * Odilia uses the speech-dispatcher client library: libspeech
-* [at-spi2-core](https://gitlab.gnome.org/GNOME/at-spi2-core) - accessibility infrestructure
-    * Odilia doesn't use libatspi, it interacts with AT-SPI over DBus directly
-    * At-spi required a DBus daemon
-* [evdev](https://manpages.ubuntu.com/manpages/jammy/man4/evdev.4.html) - input subsystem
+* [speech-dispatcher](https://freebsoft.org/speechd) >= 0.9 - text to speech daemon
+* [at-spi2-core](https://gitlab.gnome.org/GNOME/at-spi2-core) - accessibility infrastructure
+    * Odilia doesn't use libatspi, it interacts with AT-SPI over DBus directly, but the daemon must be running.
+* [systemd](https://github.com/systemd/systemd) - auto-launching for an AT-SPI daemon
 
 ## Packages
 
@@ -38,10 +33,6 @@ The following dependencies are required to build and run Odilia:
 
 Install the [odilia](https://aur.archlinux.org/packages/odilia) <sup>AUR</sup> package. This will download and build
 Odilia from source. Binary packages are planned, but currently unavailable.
-
-## Pre-built Binaries
-
-You can download pre-built Odilia binaries from [our releases page](https://github.com/odilia-app/odilia/releases).
 
 ## Building from Source
 
@@ -56,16 +47,4 @@ cargo install --path .
 
 ## Running
 
-
-To run Odilia, your user account must have access to evdev devices. Evdev is
-normally a privileged interface, since any application that can access it could
-use it for malicious purposes, for example, creating a keylogger. For this
-reason, to run Odilia, you must give yourself access to evdev. This can be done
-by running the [setup-permissions.sh shell script][permissions-script] included
-with Odilia. The script adds some udev rules, then creates an odilia group. Any
-users added to this group and the `input` group will be able to run Odilia.
-
-[permissions-script]: <https://github.com/odilia-app/odilia/blob/main/setup-permissions.sh>
-
-Once you have the correct permissions, you can start Odilia by running the
-`odilia` binary.
+Simply run the `odilia` binary created by the compilation step, or, if installed to a system path, you can simply type `odilia` in a terminal.

--- a/content/doc/user/installation.md
+++ b/content/doc/user/installation.md
@@ -2,7 +2,7 @@
 title: "Installing Odilia"
 linkTitle: "Installation"
 date: 2022-07-24T14:03:55+01:00
-draft: true
+draft: false
 weight: -20
 ---
 

--- a/content/news/release_0-1-0.md
+++ b/content/news/release_0-1-0.md
@@ -2,40 +2,47 @@
 title: "Odilia Version 0.1.0 Released"
 authors: ["tait"]
 draft: true
-date: 2022-11-27T12:30:18-06:00
+date: 2023-03-21T22:30:18-06:00
 tags:
   - release
   - odilia
 ---
 
-After many months of hard work, we are proud to announce the initial, beta release of Odilia:
-a new, *fast*, lightweight, screenreader for Linux.
-Thanks to all the others on the team: BGT Lover, and FakeVIP who have been instrumental in creating this project.
+After many months---just over a year of hard work, we are proud to announce the initial, beta release of Odilia:
+a new, fast, lightweight, screenreader for Linux.
+Thanks to all the others who have been instrumental in making Odilia possible:
 
-Don't get us wrong, this is still in its initial stages.
-However, there is enough functionality to use it, and we want to get it out into the hands of other developers and testers to make this even better for the beta 2 release (0.2), which we're aiming to complete by the end of this year (December 2022).
-**Things will break.**
-Please help us make this better so that we can create the next generation of accessible software for Linux.
+* @albertotirla (BGTLover)
+* @mcb2003 (Fake VIP)
+* @luukvanderduim (Luuk Van Der Duim)
+* @samtay (Sam Tay)
+* Federico Mena and Emmanuel Bassi at GNOME for answering my questions.
+* @lparcq (Laurent Pelecq) on Gitlab for the creation of a speech library.
+
+Don't get us wrong, this is still in its initial stages,
+and there are a lot of features to implement before we can get to an official, 1.0 release.
+However, there is enough functionality to use it, and we want to get it out into the hands of other developers and testers to make this even better for the beta 2 release (0.2), which we're aiming to complete by the end of this year (December 2023).
+
+Please help us make this better so that we can create the next generation of accessible software for open systems.
 
 Here is a quick list of what Odilia is capable of as of today:
 
 * Reading web pages
-* Limited structural navigation
-* Reading GTK and QT applications
+* Reading GTK and QT applications.
+  * GTK4 is not supported yet.
 * Configurable voices/rate via `speechd.conf`.
+* Generic input system.
+  * This means that keybindings can currently be implemented by third-party tools, although Odilia will ship with a defualt way to use keydings soon.
 
-Here is a small list of things which Odilia does not yet currently do, which we are slating for the 0.2 release later this year:
+Here is a small list of things which Odilia does not yet currently do, which we are slating for the 1.0 release:
 
-* More advanced structural navigation
-* Change voice settings from within Odilia
-
-And here is a short roadmap of what we want to complete before an official, non-testing release sometime in 2023:
-
-* Automated cache updates
-* Stability improvements
+* Support for GTK4 applications
+* Key bindings
+* MathML support
+* Change settings from within Odilia
 * Addon support
 
 We encourage those curious about new tech to [download Odilia](/doc/user/installation/) and give it a fair shake.
-We're looking forward to making this with you all!
+We're looking forward to making this better with you all!
 
----The Odilia Team
+---Tait Hoyem

--- a/content/news/release_0-1-0.md
+++ b/content/news/release_0-1-0.md
@@ -2,18 +2,18 @@
 title: "Odilia Version 0.1.0 Released"
 authors: ["tait"]
 draft: true
-date: 2022-11-05T12:30:18-06:00
+date: 2022-11-27T12:30:18-06:00
 tags:
   - release
   - odilia
 ---
 
-After many months of hard work, we are proud to announce the initial, alpha release of Odilia:
-the new, *fast*, lightweight, screenreader for Linux, written in Rust.
+After many months of hard work, we are proud to announce the initial, beta release of Odilia:
+a new, *fast*, lightweight, screenreader for Linux.
 Thanks to all the others on the team: BGT Lover, and FakeVIP who have been instrumental in creating this project.
 
 Don't get us wrong, this is still in its initial stages.
-However, there is enough functionality to use it, and we want to get it out into the hands of other developers and testers to make this even better for the alpha 2 release (0.2), which we're aiming to complete by the end of this year (December 2022).
+However, there is enough functionality to use it, and we want to get it out into the hands of other developers and testers to make this even better for the beta 2 release (0.2), which we're aiming to complete by the end of this year (December 2022).
 **Things will break.**
 Please help us make this better so that we can create the next generation of accessible software for Linux.
 

--- a/content/news/release_0-1-0.md
+++ b/content/news/release_0-1-0.md
@@ -2,7 +2,7 @@
 title: "Odilia Version 0.1.0 Released"
 authors: ["tait"]
 draft: true
-date: 2022-09-27T17:30:18-06:00
+date: 2022-11-05T12:30:18-06:00
 tags:
   - release
   - odilia
@@ -36,6 +36,6 @@ And here is a short roadmap of what we want to complete before an official, non-
 * Addon support
 
 We encourage those curious about new tech to [download Odilia](/doc/user/installation/) and give it a fair shake.
-We're looking forward to making this with you all.
+We're looking forward to making this with you all!
 
----Tait Hoyem and the Odilia team
+---The Odilia Team

--- a/content/news/release_0-1-0.md
+++ b/content/news/release_0-1-0.md
@@ -1,5 +1,5 @@
 ---
-title: "Odilia Version 0.1 Released"
+title: "Odilia Version 0.1.0 Released"
 authors: ["tait"]
 draft: true
 date: 2022-09-27T17:30:18-06:00
@@ -21,23 +21,21 @@ Here is a quick list of what Odilia is capable of as of today:
 
 * Reading web pages
 * Limited structural navigation
-* Reading GTK applications
+* Reading GTK and QT applications
 * Configurable voices/rate via `speechd.conf`.
 
 Here is a small list of things which Odilia does not yet currently do, which we are slating for the 0.2 release later this year:
 
-* Reading QT applications
 * More advanced structural navigation
 * Change voice settings from within Odilia
-* Limited addon support
 
 And here is a short roadmap of what we want to complete before an official, non-testing release sometime in 2023:
 
 * Automated cache updates
 * Stability improvements
-* Full addon support
+* Addon support
 
 We encourage those curious about new tech to [download Odilia](/doc/user/installation/) and give it a fair shake.
 We're looking forward to making this with you all.
 
--- Tait Hoyem
+---Tait Hoyem and the Odilia team

--- a/content/news/release_1.md
+++ b/content/news/release_1.md
@@ -1,0 +1,42 @@
+---
+title: "Odilia Version 0.1 Released"
+authors: ["tait"]
+date: 2022-09-27T17:30:18-06:00
+tags:
+  - release
+  - odilia
+---
+
+After many months of hard work, we are proud to announce the initial, alpha release of Odilia:
+the new, *fast*, lightweight, screenreader for Linux, written in Rust.
+Thanks to all the others on the team: BGT Lover, and FakeVIP who have been instrumental in creating this project.
+
+Don't get us wrong, this is still in its initial stages.
+However, there is enough functionality to use it, and we want to get it out into the hands of other developers and testers to make this even better for the alpha 2 release (0.2), which we're aiming to complete by the end of this year (December 2022).
+**Things will break.**
+Please help us make this better so that we can create the next generation of accessible software for Linux.
+
+Here is a quick list of what Odilia is capable of as of today:
+
+* Reading web pages
+* Limited structural navigation
+* Reading GTK applications
+* Configurable voices/rate via `speechd.conf`.
+
+Here is a small list of things which Odilia does not yet currently do, which we are slating for the 0.2 release later this year:
+
+* Reading QT applications
+* More advanced structural navigation
+* Change voice settings from within Odilia
+* Limited addon support
+
+And here is a short roadmap of what we want to complete before an official, non-testing release sometime in 2023:
+
+* Automated cache updates
+* Stability improvements
+* Full addon support
+
+We encourage those curious about new tech to [download Odilia](/doc/user/installation/) and give it a fair shake.
+We're looking forward to making this with you all.
+
+-- Tait Hoyem

--- a/content/news/release_1.md
+++ b/content/news/release_1.md
@@ -1,6 +1,7 @@
 ---
 title: "Odilia Version 0.1 Released"
 authors: ["tait"]
+draft: true
 date: 2022-09-27T17:30:18-06:00
 tags:
   - release

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -252,7 +252,7 @@ main {
 }
 
 .global-nav {
-    padding: 1rem;
+    padding: 0.2rem;
     background-color: var(--secondary-background-color);
     border-bottom: 1px solid var(--border-color);
 }
@@ -279,15 +279,7 @@ a:visited {
   color: var(--visited-link-color);
 }
 
-.local-nav-prev {
-    float: left;
-}
-
-.local-nav-prev {
-    float: right;
-}
-
-@media (max-width: 800px) {
+@media (max-width: 600px) {
   .nav-item {
       display: block;
   }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -279,7 +279,7 @@ a:visited {
   color: var(--visited-link-color);
 }
 
-@media (max-width: 600px) {
+@media (max-width: 700px) {
   .nav-item {
       display: block;
   }


### PR DESCRIPTION
The new "Documentation" section has a custom template to display sub-sections as headings to make navigating it easier. There are two subsections:

* "User Documentation" - installation instructions, user guide, configuration, FAQ, etc
* "Developer Documentation" - architecture overview, at-spi / DBus / speech-dispatcher / ... info, useful links

The old [design doc](https://odilia.app/design) is currently still there, however I've also added "/design" as an [alias](https://gohugo.io/content-management/urls/#aliases) to `content/doc/devel/design.md`, so when we remove it, it will redirect to the Design Overview:

```yaml
aliases:
  - /design
```

# Todo

* [x] Installation instructions
* [ ] User guide
* [ ] FAQ
* [ ] Info about configuration options
* [x] Design overview (needs expantion, particularly wrt. input)
* [ ] Rustdoc documentation generated by GH Actions (started, but not working yet)
* [x] Useful links
* [ ] Set `draft: false` on all pages before merge