### PR TITLE
Fix broken atspi link

### DIFF
--- a/content/doc/devel/design.md
+++ b/content/doc/devel/design.md
@@ -23,7 +23,7 @@ application-wide tasks.
 
 ### [atspi][atspi-crate] -- Accessibility Interface
 
-[atspi-crate]: <https://github.com/odilia-app/odilia/tree/main/atspi>
+[atspi-crate]: <https://github.com/odilia-app/atspi>
 
 This crate communicates with the [Assistive Technology Service Provider Interface][at-spi], which allows Odilia to
 access and present the content in applications and the desktop environment.


### PR DESCRIPTION
It seems this was one a crate in the main odilia application repo but then got moved into a separate repo? The link: https://github.com/odilia-app/odilia/tree/main/atspi appears to be dead. Updated with repo: https://github.com/odilia-app/atspi