### PR TITLE
Fix broken link.

### DIFF
--- a/content/doc/devel/design.md
+++ b/content/doc/devel/design.md
@@ -28,7 +28,7 @@ application-wide tasks.
 This crate communicates with the [Assistive Technology Service Provider Interface][at-spi], which allows Odilia to
 access and present the content in applications and the desktop environment.
 
-[at-spi]: <https://www.freedesktop.org/wiki/Accessibility/AT-SPI>
+[at-spi]: <https://www.freedesktop.org/wiki/Accessibility/AT-SPI2>
 
 ### [odilia-cache][odilia-cache] -- A Cache for Accessibile Items on the Desktop
 


### PR DESCRIPTION
Link to https://www.freedesktop.org/wiki/Accessibility/AT-SPI2/ instead of https://www.freedesktop.org/wiki/Accessibility/AT-SPI 

I am not entirely sure the difference with AT-SPI vs AT-SPI2 but I am assuming AT-SPI2 is intended since it is linked elsewhere in the site. 

I am wondering if we maybe want to include https://github.com/marketplace/actions/hugo-broken-link-check on build